### PR TITLE
fix changing of admin password (bnc#788161)

### DIFF
--- a/src/Crowbar.ycp
+++ b/src/Crowbar.ycp
@@ -46,7 +46,7 @@ import "Message";
  * Path to the files with JSON data
  */
 global string network_file = "/opt/dell/chef/data_bags/crowbar/bc-template-network.json";
-global string crowbar_file = "/opt/dell/chef/data_bags/crowbar/bc-template-crowbar.json";
+global string crowbar_file = "/etc/crowbar/crowbar.json";
 global string installed_file    = "/opt/dell/crowbar_framework/.crowbar-installed-ok";
 
 /**


### PR DESCRIPTION
install-chef-suse.sh creates the crowbar proposal from /etc/crowbar/crowbar.json
not from bc-template-crowbar.json, so the crowbar password should be changed in
the former not the latter.

See https://github.com/SUSE-Cloud/crowbar/blob/b68434022652d6a432e2f74e617dcfc8b63cc547/extra/install-chef-suse.sh#L261
