### PR TITLE
Use /etc/crowbar/network.json as path for network configuration

### DIFF
--- a/src/Crowbar.ycp
+++ b/src/Crowbar.ycp
@@ -45,7 +45,7 @@ import "Message";
 /**
  * Path to the files with JSON data
  */
-global string network_file = "/opt/dell/chef/data_bags/crowbar/bc-template-network.json";
+global string network_file = "/etc/crowbar/network.json";
 global string crowbar_file = "/etc/crowbar/crowbar.json";
 global string installed_file    = "/opt/dell/crowbar_framework/.crowbar-installed-ok";
 


### PR DESCRIPTION
This is a change in SUSE Cloud 2.0, where we don't want to change the
template files.
