### PR TITLE
Don't explicitly mention SUSE Cloud

### DIFF
--- a/package/yast2-crowbar.changes
+++ b/package/yast2-crowbar.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 26 13:54:39 UTC 2015 - tserong@suse.com
+
+- Don't explicitly mention SUSE Cloud
+- 3.1.7
+
+-------------------------------------------------------------------
 Thu Jul 23 13:56:45 CEST 2015 - jsuchome@suse.com
 
 - enable entering just SMT/Manager URL and compute the URL

--- a/package/yast2-crowbar.spec
+++ b/package/yast2-crowbar.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-crowbar
-Version:        3.1.6
+Version:        3.1.7
 Release:        0
 License:	GPL-2.0
 Group:		System/YaST

--- a/src/include/crowbar/complex.rb
+++ b/src/include/crowbar/complex.rb
@@ -1729,7 +1729,7 @@ module Yast
         Popup.Message(
           Builtins.sformat(
             _(
-              "The SUSE Cloud Admin Server has been deployed. Changing the network is\n" +
+              "The Crowbar Admin Server has been deployed. Changing the network is\n" +
                 "currently not supported.\n" +
                 "\n" +
                 "You can visit the Crowbar web UI on http://%1:3000/"

--- a/src/include/crowbar/helps.rb
+++ b/src/include/crowbar/helps.rb
@@ -48,7 +48,7 @@ module Yast
           # Ovreview dialog help
           _(
             "<p>\n" +
-              "See the SUSE Cloud deployment guide for details on the network\n" +
+              "See the product deployment guide for details on the network\n" +
               "configuration and on using this YaST module.\n" +
               "</p>"
           )


### PR DESCRIPTION
This makes some messages more generic, so they make sense when used
outside a SUSE Cloud environment, e.g. when using Crowbar to deploy
SUSE Enterprise Storage only.

Signed-off-by: Tim Serong <tserong@suse.com>