### PR TITLE
Support for repos from multiple architectures

### DIFF
--- a/package/yast2-crowbar.changes
+++ b/package/yast2-crowbar.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 27 23:14:03 UTC 2015 - vuntz@suse.com
+
+- Support for repos from multiple architectures.
+- 3.1.11
+
+-------------------------------------------------------------------
 Mon Oct 26 22:06:38 UTC 2015 - vuntz@suse.com
 
 - Update for new storage of list of repositories, in yaml files.

--- a/package/yast2-crowbar.spec
+++ b/package/yast2-crowbar.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-crowbar
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 License:	GPL-2.0
 Group:		System/YaST

--- a/src/include/crowbar/complex.rb
+++ b/src/include/crowbar/complex.rb
@@ -654,7 +654,7 @@ module Yast
           repos.each do |repo_name, r|
             url = "#{@remote_server_url}/repo/$RCE/#{repo_name}/#{arch}/"
             if @repos_location == "sm"
-              if ["SLE-Cloud","SLE-Cloud-PTF"].include? repo_name
+              if ["Cloud", "PTF"].include? repo_name
                 # some repos cannot be at SM server
                 url = ""
               else

--- a/src/include/crowbar/complex.rb
+++ b/src/include/crowbar/complex.rb
@@ -567,17 +567,14 @@ module Yast
       )
 
       ret = :not_next
-      name = ""
-      platform = "suse-12.1"
-      arch = "x86_64"
 
       while true
         ret = UI.UserInput
         break if ret == :cancel
         if ret == :ok
           name = UI.QueryWidget(Id(:name), :Value)
-          platform = UI.QueryWidget(Id(:platform), :Value)
-          arch = UI.QueryWidget(Id(:arch), :Value)
+          platform = UI.QueryWidget(Id(:platform), :Value) || "suse-12.1"
+          arch = UI.QueryWidget(Id(:arch), :Value) || "x86_64"
           if name.empty?
             ret = :cancel
             break

--- a/src/modules/Crowbar.rb
+++ b/src/modules/Crowbar.rb
@@ -31,6 +31,8 @@ require 'yaml'
 
 module Yast
   class CrowbarClass < Module
+    include Yast::Logger
+
     def main
       textdomain "crowbar"
 

--- a/src/modules/Crowbar.rb
+++ b/src/modules/Crowbar.rb
@@ -296,6 +296,8 @@ module Yast
                   repo.delete(key) unless %w(url ask_on_error).include? key
                 end
               end
+            else
+              repo["url"] = nil if repo["url"] == ""
             end
           end
           @repos[platform].delete(arch) if @repos[platform][arch].empty?

--- a/src/modules/Crowbar.rb
+++ b/src/modules/Crowbar.rb
@@ -291,9 +291,10 @@ module Yast
               # remove repos that have no change compared to defaults
               if same_repos?(default_repos_prod[repo_name], repo)
                 @repos[platform][arch].delete(repo_name)
-              end
-              repo.each do |key, val|
-                repo.delete(key) unless %w(url ask_on_error).include? key
+              else
+                repo.each do |key, val|
+                  repo.delete(key) unless %w(url ask_on_error).include? key
+                end
               end
             end
           end


### PR DESCRIPTION
We always deal with x86_64 attributes, but do not allow setting the
repos for non-x86_64 architectures.

~~Note that this contains https://github.com/yast/yast-crowbar/pull/33~~

cc @jsuchome 