### PR TITLE
Skip the installation client if crowbar packages are not installed

### DIFF
--- a/package/yast2-crowbar.changes
+++ b/package/yast2-crowbar.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 18 11:34:27 CET 2015 - jsuchome@suse.com
+
+- Skip the installation client if crowbar packages are not installed
+- 3.1.13
+
+-------------------------------------------------------------------
 Tue Nov 10 09:00:40 CET 2015 - jsuchome@suse.com
 
 - updated paths to SMT repositories

--- a/package/yast2-crowbar.spec
+++ b/package/yast2-crowbar.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-crowbar
-Version:        3.1.12
+Version:        3.1.13
 Release:        0
 Summary:        Configuration of crowbar
 License:        GPL-2.0

--- a/src/clients/inst_crowbar.rb
+++ b/src/clients/inst_crowbar.rb
@@ -33,6 +33,7 @@ module Yast
       textdomain "crowbar"
 
       Yast.import "Mode"
+      Yast.import "Package"
       Yast.import "Progress"
       Yast.import "Stage"
       Yast.import "Wizard"
@@ -47,15 +48,20 @@ module Yast
 
       @dialog_ret = :auto
 
-      Wizard.CreateDialog if Mode.normal
+      if Package.Installed("crowbar-core")
 
-      Progress.off
-      @dialog_ret = CrowbarSequence()
-      Progress.on
+        Wizard.CreateDialog if Mode.normal
 
-      Wizard.CloseDialog if Mode.normal
+        Progress.off
+        @dialog_ret = CrowbarSequence()
+        Progress.on
 
-      deep_copy(@dialog_ret)
+        Wizard.CloseDialog if Mode.normal
+      else
+        Builtins.y2milestone("Necessary packages not installed, skipping Crowbar configuration...")
+      end
+
+      @dialog_ret
     end
   end
 end


### PR DESCRIPTION
(which might happen when they are not selected for initial installation)

Not yet tested.