### PR TITLE
Do not submit the package anywhere

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,6 @@ require "yast/rake"
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/
+  # do not submit anywhere, it's maintained only for the SUSE Cloud product
+  conf.obs_sr_project = nil
 end


### PR DESCRIPTION
- It is designed only for the SUSE Cloud products, not for openSUSE or SLE.
- I talked to @jsuchome and according to him we should not submit the package to Factory or Leap
- I have asked to drop it from Factory: https://build.opensuse.org/request/show/655743
- It will be still kept in YaST:Head (at least for now)